### PR TITLE
feat(jj): add Jujutsu VCS dotfiles configuration

### DIFF
--- a/dot_jj_aliases
+++ b/dot_jj_aliases
@@ -1,0 +1,192 @@
+# -*-mode:sh-*- vim:ft=bash
+# ~/.jj_aliases
+# =============================================================================
+# Shell aliases for Jujutsu (jj) version control system.
+#
+# These aliases mirror the workflow patterns from git_aliases while
+# leveraging jj's native capabilities.
+#
+# Reference: https://docs.jj-vcs.dev/latest/
+
+# Core Operations
+# =============================================================================
+
+# Status - equivalent to 'gs' (git status -v)
+alias js='jj status'
+
+# Log - equivalent to 'decorate' (decorated git log)
+alias jl='jj log'
+
+# Log with graph of entire repo
+alias jla='jj log -r "all()"'
+
+# Log current stack from trunk
+alias jls='jj log -r "trunk()..@"'
+
+# Diff of uncommitted changes
+alias jd='jj diff'
+
+# Diff of current commit
+alias jdc='jj diff -r @'
+
+# Show current commit details
+alias jsh='jj show'
+
+# Commit Operations
+# =============================================================================
+
+# New commit (like creating a new change)
+alias jn='jj new'
+
+# Describe current commit (edit message)
+alias jde='jj describe'
+
+# Squash into parent
+alias jsq='jj squash'
+
+# Split current commit
+alias jsp='jj split'
+
+# Absorb changes into relevant commits (like git absorb)
+alias jab='jj absorb'
+
+# Edit a specific commit
+alias je='jj edit'
+
+# Abandon current commit
+alias jaban='jj abandon'
+
+# Navigation
+# =============================================================================
+
+# Go to next commit
+alias jnext='jj next'
+
+# Go to previous commit
+alias jprev='jj prev'
+
+# Bookmark/Branch Operations
+# =============================================================================
+
+# List bookmarks
+alias jb='jj bookmark list'
+
+# Create bookmark at current commit
+alias jbc='jj bookmark create'
+
+# Move bookmark to current commit
+alias jbm='jj bookmark move'
+
+# Delete bookmark
+alias jbd='jj bookmark delete'
+
+# Remote Operations (Git Backend)
+# =============================================================================
+
+# Fetch from all remotes - equivalent to 'gpa' partial
+alias jf='jj git fetch --all-remotes'
+
+# Push current bookmark
+alias jp='jj git push'
+
+# Push all bookmarks
+alias jpa='jj git push --all'
+
+# Fetch and rebase onto trunk - equivalent to 'gpa' (git fetch && pull)
+alias jfr='jj git fetch --all-remotes && jj rebase -d "trunk()"'
+
+# Sync: fetch all and rebase current stack onto trunk
+alias jsync='jj git fetch --all-remotes && jj rebase -d "trunk()"'
+
+# Rebase Operations
+# =============================================================================
+
+# Rebase current commit onto trunk
+alias jrt='jj rebase -d "trunk()"'
+
+# Rebase entire stack onto trunk
+alias jrts='jj rebase -d "trunk()" -r "trunk()..@"'
+
+# Undo/Redo
+# =============================================================================
+
+# Undo last operation
+alias ju='jj undo'
+
+# Show operation log
+alias jol='jj op log'
+
+# Restore to a specific operation
+alias jor='jj op restore'
+
+# Workspace Operations
+# =============================================================================
+
+# List workspaces
+alias jwl='jj workspace list'
+
+# Add new workspace
+alias jwa='jj workspace add'
+
+# Utility
+# =============================================================================
+
+# Show all conflicts
+alias jcon='jj log -r "conflicts()"'
+
+# Resolve conflicts
+alias jres='jj resolve'
+
+# Git interop - run git commands in colocated repo
+alias jgit='jj git'
+
+# Initialize new jj repo (colocated with git)
+alias jinit='jj git init --colocate'
+
+# Clone repository
+alias jclone='jj git clone'
+
+# File Operations
+# =============================================================================
+
+# Restore file from parent commit
+alias jrest='jj restore'
+
+# Track new files
+alias jtrack='jj file track'
+
+# Untrack files
+alias juntrack='jj file untrack'
+
+# Workflow Shortcuts
+# =============================================================================
+
+# Quick commit: describe and create new change in one flow
+# Usage: jqc "commit message"
+jqc() {
+    jj describe -m "$1" && jj new
+}
+
+# Create new bookmark and push
+# Usage: jnewbranch branch-name
+jnewbranch() {
+    jj bookmark create "$1" && jj git push --bookmark "$1"
+}
+
+# Fetch, rebase onto trunk, and push (full sync cycle)
+# Equivalent to git pull && push workflow
+jfullsync() {
+    jj git fetch --all-remotes && jj rebase -d "trunk()" && jj git push
+}
+
+# Interactive log with fzf (if available)
+if command -v fzf &> /dev/null; then
+    # Select commit to edit using fzf
+    jfe() {
+        local commit
+        commit=$(jj log --no-graph -T 'change_id.short() ++ " " ++ description.first_line() ++ "\n"' | fzf --preview 'jj show -r {1}' | awk '{print $1}')
+        if [ -n "$commit" ]; then
+            jj edit "$commit"
+        fi
+    }
+fi

--- a/dot_jjconfig.toml.tmpl
+++ b/dot_jjconfig.toml.tmpl
@@ -1,0 +1,195 @@
+# -*-mode:toml-*- vim:ft=toml
+#:schema https://docs.jj-vcs.dev/latest/config-schema.json
+# ~/.jjconfig.toml
+# =============================================================================
+# User-specific Jujutsu (jj) configuration file.
+#
+# Reference: https://docs.jj-vcs.dev/latest/config/
+#
+# {{- /* This file supports Go's text/template language. */ -}}
+#
+
+# User Settings
+# =============================================================================
+[user]
+name = "{{ if .git_user }}{{ .git_user }}{{ else }}{{ .git_username }}{{ end }}"
+email = "{{ .email }}"
+
+# Git Backend Settings
+# =============================================================================
+# Colocate jj with git for compatibility during migration
+[git]
+colocate = true
+# Automatically sign commits when pushing to remote
+sign-on-push = true
+# Track bookmarks from remotes by default
+auto-local-bookmark = true
+
+# Commit Signing (SSH - same as git config)
+# =============================================================================
+[signing]
+backend = "ssh"
+key = "{{ .chezmoi.homeDir }}/.ssh/id_ed25519.pub"
+
+# UI Settings
+# =============================================================================
+[ui]
+# Default command when running `jj` with no arguments
+default-command = ["log"]
+
+# Enable color output
+color = "auto"
+
+# Use color-words diff for better readability (similar to git's colorMoved)
+diff-formatter = ":color-words"
+
+# Use diff-style conflict markers (cleaner than snapshot, similar to zdiff3)
+conflict-marker-style = "diff"
+
+# Sort bookmarks by commit date (newest first, like git's branch.sort)
+bookmark-list-sort-keys = ["-committer-date"]
+
+# Paginate output with less
+pager = "less -FRX"
+
+# Diff Settings
+# =============================================================================
+[diff.color-words]
+# Context lines around changes
+context = 3
+# Max alternations for inline diffs
+max-inline-alternation = 3
+
+# Snapshot Settings
+# =============================================================================
+[snapshot]
+# Auto-track all files (like git add -A behavior)
+auto-track = "all()"
+# Maximum file size to auto-snapshot (1MB)
+max-new-file-size = 1048576
+
+# Aliases (in-app)
+# =============================================================================
+[aliases]
+# Quick log of recent commits (like git log --oneline)
+l = ["log", "-r", "@-..@"]
+
+# Log with all commits in current stack
+ls = ["log", "-r", "trunk()..@"]
+
+# Show status
+s = ["status"]
+
+# Describe current commit
+d = ["describe"]
+
+# Create new commit
+n = ["new"]
+
+# Squash into parent
+sq = ["squash"]
+
+# Show diff of current changes
+di = ["diff"]
+
+# Show diff of current commit
+dc = ["diff", "-r", "@"]
+
+# Fetch from all remotes
+f = ["git", "fetch", "--all-remotes"]
+
+# Push current bookmark
+p = ["git", "push"]
+
+# Absorb changes into relevant commits
+ab = ["absorb"]
+
+# Split current commit
+sp = ["split"]
+
+# Rebase onto trunk
+rt = ["rebase", "-d", "trunk()"]
+
+# Undo last operation
+u = ["undo"]
+
+# Show operation log
+ol = ["op", "log"]
+
+# Revset Aliases
+# =============================================================================
+[revset-aliases]
+# Commits that are ready to push (not empty, not WIP)
+'ready()' = 'mine() & ~empty() & ~description(regex:"(?i)^wip")'
+
+# All my work in progress
+'wip()' = 'mine() & description(regex:"(?i)^wip")'
+
+# Current stack from trunk
+'stack()' = 'trunk()..@'
+
+# All mutable commits
+'mut()' = 'mutable()'
+
+# Template Aliases
+# =============================================================================
+[template-aliases]
+# Shorter change ID display
+'format_short_id(id)' = 'id.shortest(8)'
+
+# Templates
+# =============================================================================
+[templates]
+# Include diff in commit description editor (like git commit.verbose)
+draft_commit_description = '''
+concat(
+  builtin_draft_commit_description,
+  "\nJJ: ignore-rest\n",
+  diff.stat(72),
+  "\n",
+  diff.git(),
+)
+'''
+
+# Commit trailers for signed-off-by
+commit_trailers = 'format_signed_off_by_trailer(self)'
+
+# Colors (matching a modern dark terminal theme)
+# =============================================================================
+[colors]
+# Diff colors for better visibility
+"diff removed" = { fg = "red" }
+"diff added" = { fg = "green" }
+"diff removed token" = { fg = "bright red", bold = true }
+"diff added token" = { fg = "bright green", bold = true }
+
+# Working copy highlight
+"working_copy" = { bold = true }
+"working_copy change_id" = { fg = "bright magenta", bold = true }
+"working_copy commit_id" = { fg = "bright blue", bold = true }
+
+# Bookmark/branch colors
+"bookmark" = { fg = "bright cyan" }
+"bookmarks" = { fg = "bright cyan" }
+
+# Commit metadata
+"commit_id" = { fg = "blue" }
+"change_id" = { fg = "magenta" }
+"author" = { fg = "yellow" }
+"timestamp" = { fg = "cyan" }
+"description" = { fg = "white" }
+"empty" = { fg = "bright black" }
+
+# Conflict indicator
+"conflict" = { fg = "bright red", bold = true }
+
+# Fix Tool Settings (for auto-formatting)
+# =============================================================================
+# Uncomment and configure formatters as needed:
+# [tools.rustfmt]
+# command = ["rustfmt", "--emit", "stdout"]
+# patterns = ["glob:'**/*.rs'"]
+#
+# [tools.prettier]
+# command = ["prettier", "--stdin-filepath=$path"]
+# patterns = ["glob:'**/*.{js,ts,jsx,tsx,json,md}'"]

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -88,6 +88,7 @@ fi
 # ---------------------------------------------------------------------------------
 
 [ -f {{ .chezmoi.homeDir }}/.git_aliases ] && source {{ .chezmoi.homeDir }}/.git_aliases
+[ -f {{ .chezmoi.homeDir }}/.jj_aliases ] && source {{ .chezmoi.homeDir }}/.jj_aliases
 [ -f {{ .chezmoi.homeDir }}/.bash_aliases ] && source {{ .chezmoi.homeDir }}/.bash_aliases
 [ -f {{ .chezmoi.homeDir }}/.bash_exports ] && source {{ .chezmoi.homeDir }}/.bash_exports
 [ -f {{ .chezmoi.homeDir }}/.bash_functions ] && source {{ .chezmoi.homeDir }}/.bash_functions


### PR DESCRIPTION
Add configuration for jj (Jujutsu) that aligns with existing git dotfiles:

- dot_jjconfig.toml.tmpl: Main jj config with user settings, SSH signing, UI preferences, aliases, revset aliases, and color scheme
- dot_jj_aliases: Shell aliases mirroring git workflow patterns
- Updated zshrc to source jj_aliases

Key features:
- Colocated git/jj mode for seamless migration
- SSH commit signing (same key as git)
- Color-words diff formatter and diff-style conflict markers
- In-app aliases for common operations (l, s, d, n, sq, etc.)
- Shell aliases mapping git patterns to jj (js, jl, jf, jp, jsync, etc.)
- Revset aliases for ready(), wip(), stack() workflows
- Verbose commit descriptions with diff stats


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive shell aliases for Jujutsu commands covering status, commits, navigation, and synchronization workflows.
  * Introduced Jujutsu configuration template with customizable UI settings, color theming, and predefined command shortcuts.
  * Added helper functions for multi-step operations and interactive commit selection (when fzf is available).
  * Integrated alias file sourcing into shell initialization for automatic availability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->