### PR TITLE
fix(review): address PR #16 review — trim persona preamble + skills:sync task

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -21,6 +21,11 @@ install.sh
 docs
 docs/**
 
+# Repo maintenance tooling — runs against the source tree, never deployed to ~/
+Taskfile.yml
+scripts
+scripts/**
+
 # Skills registry — read at render time, never deployed to ~/
 skills-registry.txt
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,8 @@ chezmoi diff            # preview pending changes (always before apply)
 chezmoi apply           # deploy source state to ~/
 chezmoi execute-template < file.tmpl   # test .tmpl rendering
 brew bundle --global    # install packages after apply
+task                    # list maintenance tasks (go-task)
+task skills:sync        # add locally-installed skills to skills-registry.txt
 ```
 
 ## Architecture at a Glance

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,24 @@
+# -*-mode:yaml-*- vim:ft=yaml
+# Taskfile for dotfiles maintenance (https://taskfile.dev). Not deployed to ~/.
+#
+#   task            # list available tasks
+#   task skills:sync # reconcile installed skills into skills-registry.txt
+version: "3"
+
+silent: true
+
+tasks:
+  default:
+    desc: List available tasks
+    cmds:
+      - task --list
+
+  skills:sync:
+    desc: Add locally-installed skills (from the skills CLI lockfile) to skills-registry.txt
+    cmds:
+      - ./scripts/sync-skills-registry.sh {{.CLI_ARGS}}
+
+  skills:sync:check:
+    desc: Report which installed skills are missing from skills-registry.txt (writes nothing)
+    cmds:
+      - ./scripts/sync-skills-registry.sh --dry-run

--- a/docs/ai/ai-config.md
+++ b/docs/ai/ai-config.md
@@ -67,6 +67,11 @@ run_install-skills.sh.tmpl   guard: skills_enabled == true AND npx present (else
   installer. With `skills_enabled = false` or no `npx` on `PATH`, the script prints a
   skip message and exits 0 (resilient apply).
 - **Add a skill:** append one line to `skills-registry.txt`, then `chezmoi apply`.
+- **Reconcile installed skills:** `task skills:sync` reads the `skills` CLI lockfile
+  (`~/.agents/.skill-lock.json`) and appends any locally-installed skill the registry
+  does not already declare, one entry at a time. Use `task skills:sync:check` for a
+  dry run. Local-path installs are skipped (no shareable git source); the pass is
+  idempotent, so re-running adds nothing new.
 
 ## Ownership Boundary
 

--- a/dot_Brewfile.tmpl
+++ b/dot_Brewfile.tmpl
@@ -43,6 +43,7 @@ brew "zsh-autosuggestions"
 brew "zsh-syntax-highlighting"
 brew "carapace"
 brew "jj"
+brew "go-task"
 
 {{- if not .headless }}
 # 'brew install --cask'

--- a/dot_agents/AGENTS.md
+++ b/dot_agents/AGENTS.md
@@ -1,9 +1,3 @@
-# Personal Agent Persona
-
-> Canonical AI persona for every coding tool on this machine.
-> Lives at `~/.agents/AGENTS.md`; Claude Code (`~/.claude/CLAUDE.md`) and Codex
-> (`~/.codex/AGENTS.md`) consume it via chezmoi-managed symlinks. Edit it here.
-
 ## Our working relationship
 
 - I don't like sycophancy.

--- a/scripts/sync-skills-registry.sh
+++ b/scripts/sync-skills-registry.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# Deterministically reconcile locally-installed AI skills into skills-registry.txt.
+#
+# The `skills` CLI records provenance for every installed skill in a lockfile
+# (~/.agents/.skill-lock.json, schema version 3): source, sourceType, sourceUrl,
+# skillPath. This script reads that lockfile, reconstructs the registry line for
+# each installed skill, and appends any that the registry does not already
+# declare — one entry at a time, in sorted order, so runs are reproducible.
+#
+# It is idempotent: a skill already covered by the registry (either as an
+# explicit `skill=<name>` entry or via a bare all-skills entry for the same
+# source) is skipped. Local-path skills are skipped with a warning because they
+# have no shareable git source to pin.
+#
+# Usage:
+#   scripts/sync-skills-registry.sh            # write missing entries
+#   scripts/sync-skills-registry.sh --dry-run  # report only, write nothing
+#
+# Env overrides (mainly for testing):
+#   SKILL_LOCK   path to the skills CLI lockfile (default ~/.agents/.skill-lock.json)
+#   REGISTRY     path to the registry file       (default <repo>/skills-registry.txt)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+REGISTRY="${REGISTRY:-${REPO_ROOT}/skills-registry.txt}"
+SKILL_LOCK="${SKILL_LOCK:-${HOME}/.agents/.skill-lock.json}"
+
+DRY_RUN=false
+for arg in "$@"; do
+  case "${arg}" in
+    --dry-run|-n) DRY_RUN=true ;;
+    -h|--help)
+      sed -n '2,30p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "sync-skills-registry: unknown argument '${arg}'" >&2; exit 2 ;;
+  esac
+done
+
+command -v jq >/dev/null 2>&1 || { echo "sync-skills-registry: jq is required but not on PATH." >&2; exit 1; }
+
+if [ ! -f "${SKILL_LOCK}" ]; then
+  echo "sync-skills-registry: no lockfile at ${SKILL_LOCK}; nothing installed to sync."
+  exit 0
+fi
+if [ ! -f "${REGISTRY}" ]; then
+  echo "sync-skills-registry: registry not found at ${REGISTRY}." >&2
+  exit 1
+fi
+
+# Existing registry state: skill names already declared, and sources declared
+# without a skill= token (i.e. "all skills from this source").
+declare -A DECLARED_SKILL DECLARED_ALL_SOURCE
+while IFS= read -r raw; do
+  line="${raw#"${raw%%[![:space:]]*}"}"
+  line="${line%"${line##*[![:space:]]}"}"
+  [ -z "${line}" ] && continue
+  [[ "${line}" == \#* ]] && continue
+  read -ra toks <<<"${line}"
+  src="${toks[0]}"
+  has_skill=false
+  for t in "${toks[@]:1}"; do
+    case "${t}" in
+      skill=*) DECLARED_SKILL["${t#skill=}"]=1; has_skill=true ;;
+    esac
+  done
+  ${has_skill} || DECLARED_ALL_SOURCE["${src}"]=1
+done <"${REGISTRY}"
+
+# Map the lockfile's source into a registry source token. Prefer the GitHub
+# `owner/repo` shorthand the registry already uses; otherwise normalize the
+# clone URL. Returns empty for sources with no shareable git origin.
+registry_source() {
+  local source="$1" source_type="$2" source_url="$3"
+  if [[ "${source}" == */* && "${source}" != /* && "${source}" != .* && "${source}" != *://* ]]; then
+    printf '%s' "${source}"
+    return 0
+  fi
+  case "${source_type}" in
+    local|path|file) printf '' ;;
+    *)
+      local u="${source_url:-${source}}"
+      u="${u%.git}"
+      printf '%s' "${u}"
+      ;;
+  esac
+}
+
+added=0 skipped=0
+mapfile -t names < <(jq -r '.skills | keys[]' "${SKILL_LOCK}" | sort)
+
+for name in "${names[@]}"; do
+  [ -z "${name}" ] && continue
+  source="$(jq -r --arg n "${name}" '.skills[$n].source // ""' "${SKILL_LOCK}")"
+  source_type="$(jq -r --arg n "${name}" '.skills[$n].sourceType // ""' "${SKILL_LOCK}")"
+  source_url="$(jq -r --arg n "${name}" '.skills[$n].sourceUrl // ""' "${SKILL_LOCK}")"
+
+  if [ -n "${DECLARED_SKILL[${name}]:-}" ]; then
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  reg_src="$(registry_source "${source}" "${source_type}" "${source_url}")"
+  if [ -z "${reg_src}" ]; then
+    echo "sync-skills-registry: skip '${name}' — local/unsourced install (${source_type:-unknown}); no shareable git source to pin."
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  if [ -n "${DECLARED_ALL_SOURCE[${reg_src}]:-}" ]; then
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  entry="${reg_src} skill=${name}"
+  if ${DRY_RUN}; then
+    echo "sync-skills-registry: would add: ${entry}"
+  else
+    printf '%s\n' "${entry}" >>"${REGISTRY}"
+    echo "sync-skills-registry: added:    ${entry}"
+  fi
+  added=$((added + 1))
+done
+
+if ${DRY_RUN}; then
+  echo "sync-skills-registry: ${added} entr$([ "${added}" -eq 1 ] && echo y || echo ies) missing, ${skipped} already covered (dry run; registry unchanged)."
+else
+  echo "sync-skills-registry: ${added} added, ${skipped} already covered."
+fi


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Addresses the review feedback on #16.

## Changes

### 1. Drop the canonical-location preamble from `dot_agents/AGENTS.md`
Review: _"This is not necessary and is a waste of tokens."_

Removed the `# Personal Agent Persona` title and the blockquote describing where the persona lives. This file is injected into every agent's context on every request, so the metadata was pure token overhead with no runtime value. The location/symlink detail still lives in `docs/ai/ai-config.md`.

### 2. Add `task skills:sync` to reconcile installed skills into the registry
Review: _"We should also look to adding a helper script in a task file which will deterministically scan and go one by one to add skills locally installed on the system to the skills registry."_

- `scripts/sync-skills-registry.sh` reads the `skills` CLI provenance lockfile (`~/.agents/.skill-lock.json`, schema v3), reconstructs the `owner/repo skill=<name>` registry line for each installed skill, and appends any the registry does not already declare — one entry at a time, sorted, deterministic.
- Idempotent: skips skills already covered (explicit `skill=` entry or a bare all-skills entry for the same source) and local-path installs (no shareable git source). `--dry-run` / `task skills:sync:check` previews without writing.
- `Taskfile.yml` exposes `skills:sync` and `skills:sync:check`.
- `Taskfile.yml` + `scripts/` added to `.chezmoiignore` (maintenance tooling, never deployed to `~/`); `go-task` added to the Brewfile; documented in `docs/ai/ai-config.md` and the repo/persona tooling notes.

## Validation
- `bash -n` clean; verified against the real lockfile and a simulated one covering: already-declared skill (skip), new skill (add), local-path install (skip), bare all-source entry (skip), and idempotency on re-run.

Stacked on `feat/ai-native-overhaul` so the fixes land on #16's branch.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-26345ed6-7728-4ee4-9c37-9681436553b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-26345ed6-7728-4ee4-9c37-9681436553b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

